### PR TITLE
Match price formatting with google merchant center documentation

### DIFF
--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Commerce.Cms.Models;
 using Umbraco.Commerce.Core.Api;
 using Umbraco.Commerce.Core.Models;
+using Umbraco.Commerce.Core.Services;
 using Umbraco.Commerce.Extensions;
 using Umbraco.Commerce.ProductFeeds.Core.Features.FeedGenerators.Implementations;
 using Umbraco.Commerce.ProductFeeds.Core.Features.FeedSettings.Application;

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
@@ -25,19 +25,22 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
             "Unable to find any product with these parameters: storeId = '{StoreId}', product key= '{ProductKey}', variant key = '{VariantKey}'.");
 
         private readonly ILogger<GoogleMerchantCenterFeedService> _logger;
-        private readonly IProductQueryService _productQueryService;
+        private readonly ICurrencyService _currencyService;
+        private readonly IProductQueryService _productQueryService;        
         private readonly IUmbracoCommerceApi _commerceApi;
         private readonly ISingleValuePropertyExtractorFactory _singleValuePropertyExtractorFactory;
         private readonly IMultipleValuePropertyExtractorFactory _multipleValuePropertyExtractorFactory;
 
         public GoogleMerchantCenterFeedService(
             ILogger<GoogleMerchantCenterFeedService> logger,
+            ICurrencyService currencyService,
             IProductQueryService productQueryService,
             IUmbracoCommerceApi commerceApi,
             ISingleValuePropertyExtractorFactory singleValuePropertyExtractor,
             IMultipleValuePropertyExtractorFactory multipleValuePropertyExtractorFactory)
         {
             _logger = logger;
+            _currencyService = currencyService;
             _productQueryService = productQueryService;
             _commerceApi = commerceApi;
             _singleValuePropertyExtractorFactory = singleValuePropertyExtractor;
@@ -192,7 +195,8 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
             }
 
             XmlElement priceNode = itemNode.OwnerDocument.CreateElement("g:price", GoogleXmlNamespaceUri);
-            priceNode.InnerText = productSnapshot.CalculatePrice()?.Formatted();
+            Price calculatedPrice = productSnapshot.CalculatePrice();
+            priceNode.InnerText = $"{calculatedPrice.WithTax.ToString("0.00")} {_currencyService.GetCurrency(calculatedPrice.CurrencyId).Code}";
             itemNode.AppendChild(priceNode);
         }
 


### PR DESCRIPTION
RE #7 

Added price formatting that matches the google merchant center documentation, as the changes were minor and I'm away from my PC I've done them via web browser without confirming build was successful.  If you're unable to accept the pull request I grant any permission (if it'ts needed) to reuse my changes elsewhere.

One thing to note is that google's documentation states that VAT should only be added to the price value outside the US and Canada.  I'm not sure the best way to comply with that here.

> For the US and Canada:
Don't include tax in the price.
For all other countries:
Include Value Added Tax (VAT) or goods and services tax (GST) in the price.

For reference
- https://support.google.com/merchants/answer/7052112?hl=en-GB&ref_topic=6324338&sjid=524231541191413089-EU#price_and_availability
- https://support.google.com/merchants/answer/6324371?visit_id=638538002519529514-4035416787&rd=1