### PR TITLE
Commerce Product Feeds - open PR: Support custom multiple value extractor for g:image_links node

### DIFF
--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
@@ -152,20 +152,26 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
             // add custom properties
             foreach (PropertyValueMapping map in feedSetting.PropertyNameMappings)
             {
-                if (map.ValueExtractorName == nameof(DefaultMultipleMediaPickerPropertyValueExtractor))
+                if (map.NodeName == "g:image_link")
                 {
-                    AddImageNodes(itemNode, map.ValueExtractorName, map.PropertyAlias, variant, mainProduct);
-                }
-                else
-                {
-                    ISingleValuePropertyExtractor valueExtractor = _singleValuePropertyExtractorFactory.GetExtractor(map.ValueExtractorName);
-                    string propValue = valueExtractor.Extract(variant, map.PropertyAlias, mainProduct);
-                    if (!string.IsNullOrWhiteSpace(propValue))
+                    try
                     {
-                        XmlElement propertyNode = itemNode.OwnerDocument.CreateElement(map.NodeName, GoogleXmlNamespaceUri);
-                        propertyNode.InnerText = propValue;
-                        itemNode.AppendChild(propertyNode);
+                        AddImageNodes(itemNode, map.ValueExtractorName, map.PropertyAlias, variant, mainProduct);
+                        continue;
                     }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Unable to get value for {NodeName} using {ValueExtractor}", map.NodeName, map.ValueExtractorName);
+                    }
+                }
+
+                ISingleValuePropertyExtractor valueExtractor = _singleValuePropertyExtractorFactory.GetExtractor(map.ValueExtractorName);
+                string propValue = valueExtractor.Extract(variant, map.PropertyAlias, mainProduct);
+                if (!string.IsNullOrWhiteSpace(propValue))
+                {
+                    XmlElement propertyNode = itemNode.OwnerDocument.CreateElement(map.NodeName, GoogleXmlNamespaceUri);
+                    propertyNode.InnerText = propValue;
+                    itemNode.AppendChild(propertyNode);
                 }
             }
 

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
@@ -152,7 +152,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
             // add custom properties
             foreach (PropertyValueMapping map in feedSetting.PropertyNameMappings)
             {
-                if (map.NodeName == "g:image_link")
+                if (map.NodeName == "g:image_link" && map.ValueExtractorName != nameof(DefaultMediaPickerPropertyValueExtractor))
                 {
                     try
                     {

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
@@ -19,7 +19,6 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
                 throw new ArgumentNullException(nameof(uniqueExtractorName));
             }
 
-
             IMultipleValuePropertyExtractor? valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == uniqueExtractorName)
                 ?? throw new InvalidOperationException($"Can't find property extractor with name '{uniqueExtractorName}'");
 


### PR DESCRIPTION
<p>PR:&nbsp;<a href="https://github.com/umbraco/Umbraco.Commerce.ProductFeeds/pull/27">https://github.com/umbraco/Umbraco.Commerce.ProductFeeds/pull/27</a> </p><p><br>I tried to create a custom multiple value extractor for the <code>g:image_link</code> node but it fails. </p><p>The current implementation has a check to see if <code>g:image_link</code> uses the <code>DefaultMultipleMediaPickerPropertyValueExtractor</code>, and otherwise assumes it should use a single value extractor (which will not always be the case). </p><p>In my case the image URLs are not being stored in Umbraco as a media picker so this isn't a suitable option. </p><p>I have changed the logic to check if the property is <code>g:image_link</code> but is <strong>not</strong> using the <strong>single</strong> media picker extractor (thus could be a multi-value extractor). Attempting to get an extractor unfortunately throws an exception if it does not exist, so I've wrapped this check in a try/catch block – the code then proceeds to try and use a single extractor instead. </p><p>The solution really isn't ideal, but would require a little too much rearchitecting otherwise... Happy for alternative ideas! </p>