### PR TITLE
Fix GoogleMerchantCenterFeedService to make use of multiple value property extractors

### DIFF
--- a/src/Umbraco.Commerce.ProductFeeds.Core/Extensions/XmlElementExtensions.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Extensions/XmlElementExtensions.cs
@@ -1,0 +1,28 @@
+using System.Xml;
+
+namespace Umbraco.Commerce.ProductFeeds.Core.Extensions
+{
+    internal static class XmlElementExtensions
+    {
+        /// <summary>
+        /// Add a new child node at the bottom of the list of child nodes, of this node, only when the child node inner text has value.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="childNodeName"></param>
+        /// <param name="childNodeInnerText"></param>
+        /// <param name="xmlNameSpace"></param>
+        /// <returns>The added child node or null.</returns>
+        public static XmlElement? AddChild(this XmlElement element, string childNodeName, string childNodeInnerText, string? xmlNameSpace = null)
+        {
+            if (!string.IsNullOrWhiteSpace(childNodeInnerText))
+            {
+                XmlElement childNode = element.OwnerDocument.CreateElement(childNodeName, xmlNameSpace);
+                childNode.InnerText = childNodeInnerText;
+                element.AppendChild(childNode);
+                return childNode;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedGenerators/Implementations/GoogleMerchantCenterFeedService.cs
@@ -17,6 +17,9 @@ using Umbraco.Commerce.ProductFeeds.Extensions;
 
 namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
 {
+    /// <summary>
+    /// This is the feed generator that follows Google Merchant Center's standard.
+    /// </summary>
     public class GoogleMerchantCenterFeedService : IProductFeedGeneratorService
     {
         private const string GoogleXmlNamespaceUri = "http://base.google.com/ns/1.0";
@@ -49,6 +52,12 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
             _multipleValuePropertyExtractorFactory = multipleValuePropertyExtractorFactory;
         }
 
+        /// <summary>
+        /// Generate the product feed following the inputted settings.
+        /// </summary>
+        /// <param name="feedSetting"></param>
+        /// <returns></returns>
+        /// <exception cref="IdPropertyNodeMappingNotFoundException"></exception>
         public XmlDocument GenerateFeed(ProductFeedSettingReadModel feedSetting)
         {
             ArgumentNullException.ThrowIfNull(feedSetting, nameof(feedSetting));
@@ -188,7 +197,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
         /// <summary>
         /// Add a &lt;url&gt; node under the provided &lt;item&gt; node.
         /// </summary>
-        /// <param name="itemNode"></param>
+        /// <param name="itemNode">The XML item node that represents the current product.</param>
         /// <param name="product"></param>
         private static void AddUrlNode(XmlElement itemNode, IPublishedContent product)
         {
@@ -197,9 +206,10 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
             itemNode.AppendChild(linkNode);
         }
 
+        /// <summary>
         /// Add a &lt;price&gt; node under the provided &lt;item&gt; node.
         /// </summary>
-        /// <param name="itemNode"></param>
+        /// <param name="itemNode">The XML item node that represents the current product.</param>
         /// <param name="feedSetting"></param>
         /// <param name="product"></param>
         /// <param name="complexVariant"></param>
@@ -226,14 +236,14 @@ namespace Umbraco.Commerce.ProductFeeds.Core.FeedGenerators.Implementations
         /// <summary>
         /// Add image nodes under the provided &lt;item&gt; node.
         /// </summary>
-        /// <param name="itemNode"></param>
-        /// <param name="valueExtractorName"></param>
+        /// <param name="itemNode">The XML item node that represents the current product.</param>
+        /// <param name="valueExtractorId"></param>
         /// <param name="propertyAlias"></param>
         /// <param name="product"></param>
         /// <param name="mainProduct"></param>
-        private void AddImageNodes(XmlElement itemNode, string valueExtractorName, string propertyAlias, IPublishedElement product, IPublishedElement? mainProduct)
+        private void AddImageNodes(XmlElement itemNode, string valueExtractorId, string propertyAlias, IPublishedElement product, IPublishedElement? mainProduct)
         {
-            IMultipleValuePropertyExtractor multipleValuePropertyExtractor = _multipleValuePropertyExtractorFactory.GetExtractor(valueExtractorName);
+            IMultipleValuePropertyExtractor multipleValuePropertyExtractor = _multipleValuePropertyExtractorFactory.GetExtractor(valueExtractorId);
             var imageUrls = multipleValuePropertyExtractor.Extract(product, propertyAlias, mainProduct).ToList();
             if (imageUrls.Count <= 0)
             {

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedSettings/Application/PropertyValueMapping.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/FeedSettings/Application/PropertyValueMapping.cs
@@ -15,6 +15,12 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.FeedSettings.Application
         /// <summary>
         /// Property value extractor id.
         /// </summary>
+        [Obsolete("Will be removed in v15. Use ValueExtractorId instead.")]
         public string? ValueExtractorName { get; set; }
+
+        /// <summary>
+        /// Property value extractor id.
+        /// </summary>
+        public string? ValueExtractorId => ValueExtractorName;
     }
 }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/IMultipleValuePropertyExtractor.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/IMultipleValuePropertyExtractor.cs
@@ -7,16 +7,22 @@ namespace Umbraco.Commerce.ProductFeeds.Core.PropertyValueExtractors.Application
     /// </summary>
     public interface IMultipleValuePropertyExtractor
     {
+        /// <summary>
+        /// The unique id of this extractor.
+        /// </summary>
         string Id { get; }
 
+        /// <summary>
+        /// The user friendly name of this extractor.
+        /// </summary>
         string DisplayName { get; }
 
         /// <summary>
-        /// Get a list of absolute url of the media.
+        /// Extracts the value from the property and returns them as a collection.
         /// </summary>
-        /// <param name="content"></param>
+        /// <param name="content">The umbraco content that holds the property.</param>
         /// <param name="propertyAlias"></param>
-        /// <param name="fallbackElement"></param>
+        /// <param name="fallbackElement">If the property alias can't be found on the main content, this method should try looking for it on the fallback content.</param>
         /// <returns></returns>
         ICollection<string> Extract(IPublishedElement content, string propertyAlias, IPublishedElement? fallbackElement);
     }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/IMultipleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/IMultipleValuePropertyExtractorFactory.cs
@@ -5,8 +5,8 @@ namespace Umbraco.Commerce.ProductFeeds.Core.PropertyValueExtractors.Application
         /// <summary>
         /// Get the property extractor.
         /// </summary>
-        /// <param name="uniqueExtractorName"></param>
+        /// <param name="valueExtractorId"></param>
         /// <returns></returns>
-        IMultipleValuePropertyExtractor GetExtractor(string uniqueExtractorName);
+        IMultipleValuePropertyExtractor GetExtractor(string valueExtractorId);
     }
 }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/IMultipleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/IMultipleValuePropertyExtractorFactory.cs
@@ -7,6 +7,15 @@ namespace Umbraco.Commerce.ProductFeeds.Core.PropertyValueExtractors.Application
         /// </summary>
         /// <param name="valueExtractorId"></param>
         /// <returns></returns>
+        [Obsolete("Will be removed in v15. Use TryGetExtractor instead.")]
         IMultipleValuePropertyExtractor GetExtractor(string valueExtractorId);
+
+        /// <summary>
+        /// Try to get the property extractor. Returns the default extractor implementation if no extractor id is provided.
+        /// </summary>
+        /// <param name="valueExtractorId"></param>
+        /// <param name="valueExtractor">The located value extractor. It can be null if no extractor was found.</param>
+        /// <returns>True if an extractor was found, otherwise False.</returns>
+        bool TryGetExtractor(string valueExtractorId, out IMultipleValuePropertyExtractor? valueExtractor) => throw new NotImplementedException();
     }
 }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/ISingleValuePropertyExtractor.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/ISingleValuePropertyExtractor.cs
@@ -7,16 +7,22 @@ namespace Umbraco.Commerce.ProductFeeds.Core.PropertyValueExtractors.Application
     /// </summary>
     public interface ISingleValuePropertyExtractor
     {
+        /// <summary>
+        /// Returns the value extractor id. Must be unique.
+        /// </summary>
         public string Id { get; }
 
+        /// <summary>
+        /// Returns a user friendly name of the value extractor.
+        /// </summary>
         public string DisplayName { get; }
 
         /// <summary>
-        /// Get property value using property alias.
+        /// Gets property value using property alias.
         /// </summary>
         /// <param name="content"></param>
         /// <param name="propertyAlias"></param>
-        /// <param name="fallbackElement">Store fallback value of the property.</param>
+        /// <param name="fallbackElement">Stores fallback value of the property.</param>
         /// <returns></returns>
         string Extract(IPublishedElement content, string propertyAlias, IPublishedElement? fallbackElement);
     }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/ISingleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Application/ISingleValuePropertyExtractorFactory.cs
@@ -3,10 +3,19 @@ namespace Umbraco.Commerce.ProductFeeds.Core.PropertyValueExtractors.Application
     public interface ISingleValuePropertyExtractorFactory
     {
         /// <summary>
-        /// Get the property extractor. Returns the default extractor implementation if no extractor name is provided.
+        /// Get the property extractor. Returns the default extractor implementation if no extractor id is provided.
         /// </summary>
         /// <param name="extractorId"></param>
         /// <returns></returns>
+        [Obsolete("Will be removed in v15. Use TryGetExtractor instead.")]
         ISingleValuePropertyExtractor GetExtractor(string? extractorId = null);
+
+        /// <summary>
+        /// Try to get the property extractor. Returns the default extractor implementation if no extractor id is provided.
+        /// </summary>
+        /// <param name="extractorId"></param>
+        /// <param name="extractor">The located value extractor. It can be null if no extractor was found.</param>
+        /// <returns>True if an extractor was found, otherwise False.</returns>
+        bool TryGetExtractor(string? extractorId, out ISingleValuePropertyExtractor? extractor) => throw new NotImplementedException();
     }
 }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
@@ -12,16 +12,16 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
         }
 
         /// <inheritdoc/>
-        public IMultipleValuePropertyExtractor GetExtractor(string uniqueExtractorName)
+        public IMultipleValuePropertyExtractor GetExtractor(string valueExtractorId)
         {
-            if (string.IsNullOrWhiteSpace(uniqueExtractorName))
+            if (string.IsNullOrWhiteSpace(valueExtractorId))
             {
-                throw new ArgumentNullException(nameof(uniqueExtractorName));
+                throw new ArgumentNullException(nameof(valueExtractorId));
             }
 
 
-            IMultipleValuePropertyExtractor? valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == uniqueExtractorName)
-                ?? throw new InvalidOperationException($"Can't find property extractor with name '{uniqueExtractorName}'");
+            IMultipleValuePropertyExtractor? valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == valueExtractorId)
+                ?? throw new InvalidOperationException($"Can't find property extractor with name '{valueExtractorId}'");
 
             return valueExtractor;
         }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
         }
 
         /// <inheritdoc/>
+        [Obsolete("Will be removed in v15. Use TryGetExtractor instead.")]
         public IMultipleValuePropertyExtractor GetExtractor(string valueExtractorId)
         {
             if (string.IsNullOrWhiteSpace(valueExtractorId))
@@ -19,11 +20,22 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
                 throw new ArgumentNullException(nameof(valueExtractorId));
             }
 
-
             IMultipleValuePropertyExtractor? valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == valueExtractorId)
                 ?? throw new InvalidOperationException($"Can't find property extractor with id '{valueExtractorId}'");
 
             return valueExtractor;
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetExtractor(string valueExtractorId, out IMultipleValuePropertyExtractor? valueExtractor)
+        {
+            if (string.IsNullOrWhiteSpace(valueExtractorId))
+            {
+                throw new ArgumentNullException(nameof(valueExtractorId));
+            }
+
+            valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == valueExtractorId);
+            return valueExtractor != null ? true : false;
         }
     }
 }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/MultipleValuePropertyExtractorFactory.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
 
 
             IMultipleValuePropertyExtractor? valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == valueExtractorId)
-                ?? throw new InvalidOperationException($"Can't find property extractor with name '{valueExtractorId}'");
+                ?? throw new InvalidOperationException($"Can't find property extractor with id '{valueExtractorId}'");
 
             return valueExtractor;
         }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/SingleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/SingleValuePropertyExtractorFactory.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
             }
 
             ISingleValuePropertyExtractor? valueExtractor = _valueExtractors.FirstOrDefault(x => x.Id == extractorId)
-                ?? throw new InvalidOperationException($"Can't find property extractor with name '{extractorId}'");
+                ?? throw new InvalidOperationException($"Can't find property extractor with id '{extractorId}'");
 
             return valueExtractor;
         }

--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/SingleValuePropertyExtractorFactory.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/SingleValuePropertyExtractorFactory.cs
@@ -4,6 +4,9 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
 {
     public class SingleValuePropertyExtractorFactory : ISingleValuePropertyExtractorFactory
     {
+        /// <summary>
+        /// Registered single value property extractors.
+        /// </summary>
         private readonly SingleValuePropertyExtractorCollection _valueExtractors;
 
         public SingleValuePropertyExtractorFactory(SingleValuePropertyExtractorCollection valueExtractors)
@@ -12,6 +15,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
         }
 
         /// <inheritdoc/>
+        [Obsolete("Will be removed in v15. Use TryGetExtractor instead.")]
         public ISingleValuePropertyExtractor GetExtractor(string? extractorId = null)
         {
             if (string.IsNullOrWhiteSpace(extractorId))
@@ -23,6 +27,19 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
                 ?? throw new InvalidOperationException($"Can't find property extractor with id '{extractorId}'");
 
             return valueExtractor;
+        }
+
+
+        /// <inheritdoc/>
+        public bool TryGetExtractor(string? extractorId, out ISingleValuePropertyExtractor? extractor)
+        {
+            if (string.IsNullOrWhiteSpace(extractorId))
+            {
+                extractorId = nameof(DefaultSingleValuePropertyExtractor);
+            }
+
+            extractor = _valueExtractors.FirstOrDefault(x => x.Id == extractorId);
+            return extractor != null ? true : false;
         }
     }
 }

--- a/src/Umbraco.Commerce.ProductFeeds.Startup/Initializations/IUmbracoCommerceBuilderExtensions.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Startup/Initializations/IUmbracoCommerceBuilderExtensions.cs
@@ -18,6 +18,7 @@ using Umbraco.Commerce.ProductFeeds.Startup.Initializations;
 
 namespace Umbraco.Commerce.ProductFeeds.Extensions
 {
+    [Obsolete("Will be moved to Umbraco.Commerce.Extensions namespace in v15.")]
     public static class IUmbracoCommerceBuilderExtensions
     {
         /// <summary>
@@ -25,6 +26,7 @@ namespace Umbraco.Commerce.ProductFeeds.Extensions
         /// </summary>
         /// <param name="ucBuilder"></param>
         /// <returns></returns>
+        [Obsolete("Will be moved to Umbraco.Commerce.Extensions namespace in v15.")]
         public static IUmbracoCommerceBuilder AddCommerceProductFeeds(this IUmbracoCommerceBuilder ucBuilder)
         {
             ArgumentNullException.ThrowIfNull(ucBuilder, "umbracoCommerceBuilder");

--- a/src/Umbraco.Commerce.ProductFeeds.Web/Apis/Public/XmlActionResult.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Web/Apis/Public/XmlActionResult.cs
@@ -33,7 +33,9 @@ public sealed class XmlActionResult : IActionResult
             {
                 writer.Formatting = Formatting;
                 _document.WriteContentTo(writer);
+#pragma warning disable CA1849 // The FlushAsync is not implemented
                 writer.Flush();
+#pragma warning restore CA1849 // The FlushAsync is not implemented
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
This PR addresses issue in #27 
IMultipleValuePropertyExtractor generates multiple nodes under the same name.
![image](https://github.com/user-attachments/assets/6511a883-18d4-4ccb-8bae-169d5c22df01)

A nightly build `13.1.3--preview.2+3d4c292` is available on [Umbraco nightly build feed](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/install/installing-nightly-builds).

The stable version will be pushed to nuget on March 17th, 2025