### PR TITLE
Updated Multiple Media extractor to use MediaWithCrops as per later versions

### DIFF
--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/DefaultMultipleMediaPickerPropertyValueExtractor.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/DefaultMultipleMediaPickerPropertyValueExtractor.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Commerce.ProductFeeds.Core.PropertyValueExtractors.Application;
 using Umbraco.Commerce.ProductFeeds.Extensions;
@@ -18,7 +19,7 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
                 return new List<string>();
             }
 
-            List<IPublishedContent>? medias = content.GetPropertyValue<List<IPublishedContent>>(propertyAlias, fallbackElement);
+            List<MediaWithCrops>? medias = content.GetPropertyValue<List<MediaWithCrops>>(propertyAlias, fallbackElement);
             if (medias == null || medias.Count == 0)
             {
                 return new List<string>();


### PR DESCRIPTION
V13 fails for images that use MediaWithCrops as the extractor treats the property as IPubishedContent
I notice this has been fixed in later versions so I've updated the v13 code to match - i.e. switched the property type to MediaWithCrops