### PR TITLE
 Fix Umbraco Commerce Product Feeds excludes products with no variants;  handle the unable to cast exception in DefaultMediaPickerPropertyValueExtractor

### DIFF
--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/DefaultMultipleMediaPickerPropertyValueExtractor.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/DefaultMultipleMediaPickerPropertyValueExtractor.cs
@@ -13,18 +13,17 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
         /// <inheritdoc/>
         public ICollection<string> Extract(IPublishedElement content, string propertyAlias, IPublishedElement? fallbackElement)
         {
-            if (!content.HasProperty(propertyAlias))
+            IEnumerable<IPublishedContent>? items = content.GetPropertyValue<IEnumerable<IPublishedContent>>(propertyAlias, fallbackElement);
+            if (items == null)
             {
-                return new List<string>();
+                return [];
             }
 
-            List<IPublishedContent>? medias = content.GetPropertyValue<List<IPublishedContent>>(propertyAlias, fallbackElement);
-            if (medias == null || medias.Count == 0)
-            {
-                return new List<string>();
-            }
-
-            return medias.Select(x => x.MediaUrl(mode: UrlMode.Absolute)).ToList();
+            return items
+                .Where(x => x != null)
+                .Select(x => x.MediaUrl(mode: UrlMode.Absolute))
+                .ToList();
         }
+
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
- Fix "Umbraco Commerce Product Feeds excludes products with no variants" (https://github.com/umbraco/Umbraco.Commerce.Issues/issues/757)

- Handle the unable to cast exception in `DefaultMediaPickerPropertyValueExtractor`, which eventually fixes  https://github.com/umbraco/Umbraco.Commerce.ProductFeeds/pull/49