### PR TITLE
Sanitize strings in single value property extractor

### DIFF
--- a/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/DefaultSingleValuePropertyExtractor.cs
+++ b/src/Umbraco.Commerce.ProductFeeds.Core/Features/PropertyValueExtractors/Implementations/DefaultSingleValuePropertyExtractor.cs
@@ -1,11 +1,12 @@
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Commerce.ProductFeeds.Extensions;
 using Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Application;
+using Umbraco.Extensions;
 
 namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Implementations
 {
     /// <summary>
-    /// Simply returns .ToString() value of the property.
+    /// Returns string value of the property, trims whitespace and HTML
     /// </summary>
     public class DefaultSingleValuePropertyExtractor : ISingleValuePropertyExtractor
     {
@@ -18,7 +19,15 @@ namespace Umbraco.Commerce.ProductFeeds.Core.Features.PropertyValueExtractors.Im
         {
             ArgumentNullException.ThrowIfNull(content);
 
-            return content.GetPropertyValue<object?>(propertyAlias, fallbackElement)?.ToString() ?? string.Empty;
+            var value = content.GetPropertyValue<object?>(propertyAlias, fallbackElement)?.ToString();
+
+            // trim whitespace
+            value = value?.Trim();
+
+            // strip HTML
+            value = value?.StripHtml();
+
+            return value ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
HTML is not allowed in Google Merchant Center product feed values.

This can happen when including an RTE field (for example).

This change strips leading / trailing whitespace and any HTML tags using Umbraco's lightweight helper methods.

It would be great if this could be backported to V13 also... 😄

---
_This item has been added to our backlog AB#63068_